### PR TITLE
Fix file check (language support)?

### DIFF
--- a/ipa2/main.py
+++ b/ipa2/main.py
@@ -5,6 +5,7 @@ import pkg_resources
 
 
 class IPA2:
+
     def __init__(self, lang="yue"):
         super().__init__()
         self.data = {}
@@ -15,7 +16,8 @@ class IPA2:
                 self.data.update(self.load_lang_to_list(i))
 
     def load_lang_to_list(self, lang):
-        file_loc = pkg_resources.resource_filename(__name__, "data/" + lang + ".tsv")
+        file_loc = pkg_resources.resource_filename(__name__,
+                                                   "data/" + lang + ".tsv")
         if nlp2.is_file_exist(file_loc):
             tdict = nlp2.read_csv(file_loc, delimiter="\t")
             t = {}
@@ -37,7 +39,7 @@ class IPA2:
         while start < senlen:
             matched = False
             for i in range(senlen, 0, -1):
-                string = "".join(input[start : start + i])
+                string = "".join(input[start:start + i])
                 if string in self.data:
                     result.append(string)
                     matched = True
@@ -54,4 +56,5 @@ class IPA2:
                 ipa_result.append(self.data[i].split(","))
             else:
                 not_converted_char.append(i)
-        return [" ".join(x) for x in itertools.product(*ipa_result)], not_converted_char
+        return [" ".join(x)
+                for x in itertools.product(*ipa_result)], not_converted_char

--- a/ipa2/main.py
+++ b/ipa2/main.py
@@ -23,7 +23,11 @@ class IPA2:
                 t[i[0]] = i[1]
             return t
         else:
-            assert FileNotFoundError
+            raise FileNotFoundError(
+                f"""{lang} not supported as `"""
+                f"data/{lang}.tsv"
+                """` is not provided..."""
+            )
 
     def convert_sent(self, input='測試的句子'):
         not_converted_char = []

--- a/ipa2/main.py
+++ b/ipa2/main.py
@@ -5,7 +5,7 @@ import pkg_resources
 
 
 class IPA2:
-    def __init__(self, lang='yue'):
+    def __init__(self, lang="yue"):
         super().__init__()
         self.data = {}
         if isinstance(lang, str):
@@ -15,9 +15,9 @@ class IPA2:
                 self.data.update(self.load_lang_to_list(i))
 
     def load_lang_to_list(self, lang):
-        file_loc = pkg_resources.resource_filename(__name__, 'data/' + lang + '.tsv')
+        file_loc = pkg_resources.resource_filename(__name__, "data/" + lang + ".tsv")
         if nlp2.is_file_exist(file_loc):
-            tdict = nlp2.read_csv(file_loc, delimiter='\t')
+            tdict = nlp2.read_csv(file_loc, delimiter="\t")
             t = {}
             for i in tdict:
                 t[i[0]] = i[1]
@@ -29,7 +29,7 @@ class IPA2:
                 """` is not provided..."""
             )
 
-    def convert_sent(self, input='測試的句子'):
+    def convert_sent(self, input="測試的句子"):
         not_converted_char = []
         input = nlp2.split_sentence_to_array(input, False)
         result = []
@@ -39,7 +39,7 @@ class IPA2:
         while start < senlen:
             matched = False
             for i in range(senlen, 0, -1):
-                string = "".join(input[start:start + i])
+                string = "".join(input[start : start + i])
                 if string in self.data:
                     result.append(string)
                     matched = True

--- a/ipa2/main.py
+++ b/ipa2/main.py
@@ -15,7 +15,8 @@ class IPA2:
                 self.data.update(self.load_lang_to_list(i))
 
     def load_lang_to_list(self, lang):
-        file_loc = pkg_resources.resource_filename(__name__, "data/" + lang + ".tsv")
+        file_loc = pkg_resources.resource_filename(
+            __name__, "data/" + lang + ".tsv")
         if nlp2.is_file_exist(file_loc):
             tdict = nlp2.read_csv(file_loc, delimiter="\t")
             t = {}
@@ -37,7 +38,7 @@ class IPA2:
         while start < senlen:
             matched = False
             for i in range(senlen, 0, -1):
-                string = "".join(input[start : start + i])
+                string = "".join(input[start: start + i])
                 if string in self.data:
                     result.append(string)
                     matched = True

--- a/ipa2/main.py
+++ b/ipa2/main.py
@@ -24,9 +24,7 @@ class IPA2:
             return t
         else:
             raise FileNotFoundError(
-                f"""{lang} not supported as `"""
-                f"data/{lang}.tsv"
-                """` is not provided..."""
+                f"{lang} not supported as `data/{lang}.tsv` is not provided..."
             )
 
     def convert_sent(self, input="測試的句子"):

--- a/ipa2/main.py
+++ b/ipa2/main.py
@@ -15,8 +15,7 @@ class IPA2:
                 self.data.update(self.load_lang_to_list(i))
 
     def load_lang_to_list(self, lang):
-        file_loc = pkg_resources.resource_filename(
-            __name__, "data/" + lang + ".tsv")
+        file_loc = pkg_resources.resource_filename(__name__, "data/" + lang + ".tsv")
         if nlp2.is_file_exist(file_loc):
             tdict = nlp2.read_csv(file_loc, delimiter="\t")
             t = {}
@@ -38,7 +37,7 @@ class IPA2:
         while start < senlen:
             matched = False
             for i in range(senlen, 0, -1):
-                string = "".join(input[start: start + i])
+                string = "".join(input[start : start + i])
                 if string in self.data:
                     result.append(string)
                     matched = True


### PR DESCRIPTION
The `FileNotFoundError` should not be ***asserted*** but ***`raise`d*** instead? As

```python
assert FileNotFoundError
```

makes nothing happen. ...

I guess that this is to check if `lang` is in `data`, and the absence of `lang` implies that it is still not supported.